### PR TITLE
Join first voice channel available

### DIFF
--- a/thebard.js
+++ b/thebard.js
@@ -35,7 +35,7 @@ if(config.welcomeUser){
 bot.on('message', message => {
   if (message.content.startsWith('!sing')) {
 		// Join audio channel
-		message.member.voice.channel.join()
+		message.guild.channels.cache.filter(function (channel) { return channel.type === 'voice' }).first().join()
 			.then(function (connection) {
 				connection.play(config.iceCastUrl);
 				message.channel.send('playing time!')


### PR DESCRIPTION
The bot will crash if the user that sent the "!sing" command is not currently in a voice channel. 

I resolve this by letting the bot join the first (in my use case only) voice channel of the server.

A try/catch block arround could also be nice :)